### PR TITLE
Readme update - Add claude configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ npm run deploy
 
 Connect to your deployed MCP server in Cursor or Claude Desktop using the provided URL.
 
+### Claude Desktop Configuration
+
+Add this to your Claude Desktop configuration file:
+
+```json
+{
+  "mcpServers": {
+    "any-name-you-want-to-provide-for-claude": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://xxxx.adobeioruntime.net/api/v1/web/your-project/mcp-server"
+      ]
+    }
+  }
+}
+```
+
+
 
 ## MCP Features
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add configs for claude in readme


## Motivation and Context

Users can use the similar configs in claude depending on their own url , so that this server can be used with claude destop. 

