### PR TITLE
Release 0.2.0 - Fixes MCP SDK 1.24+ compatibility with Node.js 18/20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/generator-app-remote-mcp-server-generic",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Adobe I/O Appbuilder template for MCP server implementation with Appbuilder actions.",
   "main": "src/index.js",
   "engines": {

--- a/src/templates/actions/mcp-server/index.js
+++ b/src/templates/actions/mcp-server/index.js
@@ -310,7 +310,7 @@ function handleHealthCheck () {
             status: 'healthy',
             server: '<%= projectName %>',
             version: '1.0.0',
-            description: 'Adobe I/O Runtime MCP Server using official TypeScript SDK v1.17.4',
+            description: 'Adobe I/O Runtime MCP Server using official TypeScript SDK MCP v1.24.x',
             timestamp: new Date().toISOString(),
             transport: 'StreamableHTTP',
             sdk: '@modelcontextprotocol/sdk'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

New version release for support of new MCP SDK 1.24.x https://github.com/adobe/generator-app-remote-mcp-server-generic/pull/20

## Related Issue

Upgrade version support from 1.17.4 to 1.24.x


