### PR TITLE
Add authentication layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 node_modules
 
 .env*
+!.env.example
 .aio
 
 # Test output
@@ -26,3 +27,5 @@ coverage
 
 # this template's e2e test directory
 temp-template-test
+
+.cursor

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Generate **MCP servers** that run on Adobe I/O Runtime. Connect AI assistants li
 - 📝 **Type Safety**: Zod schema validation for all parameters
 - 🚀 **Serverless Ready**: Deploy to Adobe I/O Runtime with auto-scaling
 - 🛠️ **Complete MCP Implementation**: Tools, Resources, and Prompts support
+- 🔐 **Built-in Authentication**: IMS token validation and API key support
 - 📚 **Production Ready**: Error handling, logging, and CORS included
 
 ## Quick Start
@@ -99,6 +100,110 @@ Add this to your Claude Desktop configuration file:
 **Prompts**: Reusable prompt templates with parameters
 
 All implemented using the official MCP TypeScript SDK  
+
+## Authentication
+
+The generated MCP servers include built-in authentication support to secure your endpoints:
+
+### IMS Token Validation (Adobe Users)
+
+Validate Bearer tokens via Adobe IMS userinfo endpoint. Ideal for Adobe employee or partner authentication.
+
+**Setup:**
+```bash
+# Set in .env or app.config.yaml
+AUTH_VALIDATE_IMS=true
+```
+
+**Client Configuration (Cursor):**
+```json
+{
+  "mcpServers": {
+    "my-mcp": {
+      "url": "https://namespace.adobeioruntime.net/api/v1/web/pkg/mcp-server",
+      "type": "streamable-http",
+      "headers": {
+        "Authorization": "Bearer YOUR_IMS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+**Client Configuration (Claude Desktop):**
+```json
+{
+  "mcpServers": {
+    "my-mcp": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://namespace.adobeioruntime.net/api/v1/web/pkg/mcp-server",
+        "--header",
+        "Authorization:${IMS_TOKEN}"
+      ],
+      "env": {
+        "IMS_TOKEN": "Bearer YOUR_IMS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+### API Key Authentication (Service-to-Service)
+
+Simple key-based authentication for service-to-service communication.
+
+**Setup:**
+```bash
+# Set in .env or app.config.yaml
+SERVICE_API_KEY=your-secret-key-here
+```
+
+**Client Configuration (Cursor):**
+```json
+{
+  "mcpServers": {
+    "my-mcp": {
+      "url": "https://namespace.adobeioruntime.net/api/v1/web/pkg/mcp-server",
+      "type": "streamable-http",
+      "headers": {
+        "x-api-key": "your-secret-key-here"
+      }
+    }
+  }
+}
+```
+
+**Client Configuration (Claude Desktop):**
+```json
+{
+  "mcpServers": {
+    "my-mcp": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://namespace.adobeioruntime.net/api/v1/web/pkg/mcp-server",
+        "--header",
+        "x-api-key:${API_KEY}"
+      ],
+      "env": {
+        "API_KEY": "your-secret-key-here"
+      }
+    }
+  }
+}
+```
+
+### No Authentication (Development Only)
+
+Leave both variables unset for open access during development. **Not recommended for production.**
+
+**Security Best Practices:**
+- Always enable authentication in production deployments
+- Use strong random values for `SERVICE_API_KEY`
+- Never commit secrets to version control
+- Rotate API keys regularly
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/generator-app-remote-mcp-server-generic",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Adobe I/O Appbuilder template for MCP server implementation with Appbuilder actions.",
   "main": "src/index.js",
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -203,6 +203,7 @@ class McpIoRuntimeGenerator extends ActionGenerator {
       'actions/mcp-server/index.js',
       'actions/mcp-server/node18-web-globals.js',
       'actions/mcp-server/tools.js',
+      'actions/mcp-server/validator.js',
       'actions/mcp-server/webpack.config.js',
       'test/jest.setup.js',
       'test/mcp-server.test.js',
@@ -236,6 +237,13 @@ class McpIoRuntimeGenerator extends ActionGenerator {
     this.fs.copyTpl(
       this.templatePath('_dot.gitignore'),
       this.destinationPath(path.join(destFolder, '.gitignore')),
+      templateProps
+    )
+
+    // Copy .env.example for environment variable configuration
+    this.fs.copyTpl(
+      this.templatePath('.env.example'),
+      this.destinationPath(path.join(destFolder, '.env.example')),
       templateProps
     )
 

--- a/src/templates/.env.example
+++ b/src/templates/.env.example
@@ -1,0 +1,12 @@
+# Adobe I/O Runtime MCP Server - Environment Variables
+# Copy this file to .env and fill in your values
+
+# Logging
+LOG_LEVEL=
+
+# Authentication
+# Set AUTH_VALIDATE_IMS=true to enable IMS token validation via Adobe IMS userinfo endpoint
+AUTH_VALIDATE_IMS=
+
+# Set SERVICE_API_KEY for simple API key authentication (service-to-service)
+SERVICE_API_KEY=

--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -2,4 +2,124 @@
 
 Create [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers for Adobe I/O Runtime using the **official MCP TypeScript SDK**. Connect AI assistants like Cursor and Claude Desktop to your custom tools, resources, and prompts.
 
-This Project is generated using https://github.com/OneAdobe/app-builder-remote-mcp-server-starter template. 
+This Project is generated using https://github.com/OneAdobe/app-builder-remote-mcp-server-starter template.
+
+## Authentication
+
+The MCP server supports two authentication modes to secure your endpoints:
+
+### IMS Token Validation (Adobe Users)
+
+Set `AUTH_VALIDATE_IMS=true` to validate Bearer tokens via Adobe IMS userinfo endpoint. This is ideal for Adobe employee or partner authentication.
+
+**Configuration:**
+
+```bash
+# In .env or workspace config
+AUTH_VALIDATE_IMS=true
+```
+
+**Cursor Configuration:**
+
+```json
+{
+  "mcpServers": {
+    "my-mcp": {
+      "url": "https://namespace.adobeioruntime.net/api/v1/web/pkg/mcp-server",
+      "type": "streamable-http",
+      "headers": {
+        "Authorization": "Bearer YOUR_IMS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+**Claude Desktop Configuration:**
+
+```json
+{
+  "mcpServers": {
+    "my-mcp": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://namespace.adobeioruntime.net/api/v1/web/pkg/mcp-server",
+        "--header",
+        "Authorization:${IMS_TOKEN}"
+      ],
+      "env": {
+        "IMS_TOKEN": "Bearer YOUR_IMS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+**Note:** Claude Desktop on Windows has a bug with spaces in args. Use `Authorization:${IMS_TOKEN}` (no space after colon) and put the full `Bearer YOUR_IMS_TOKEN` in the env variable.
+
+### API Key Authentication (Service-to-Service)
+
+Set `SERVICE_API_KEY` for simple key-based authentication. This is ideal for service-to-service communication or custom client applications.
+
+**Configuration:**
+
+```bash
+# In .env or workspace config
+SERVICE_API_KEY=your-secret-key-here
+```
+
+The client must send the API key in either the `Authorization` header or `x-api-key` header:
+
+```bash
+# Using Authorization header
+curl -H "Authorization: Bearer your-secret-key-here" \
+  https://namespace.adobeioruntime.net/api/v1/web/pkg/mcp-server
+
+# Using x-api-key header
+curl -H "x-api-key: your-secret-key-here" \
+  https://namespace.adobeioruntime.net/api/v1/web/pkg/mcp-server
+```
+
+**Cursor Configuration:**
+
+```json
+{
+  "mcpServers": {
+    "my-mcp": {
+      "url": "https://namespace.adobeioruntime.net/api/v1/web/pkg/mcp-server",
+      "type": "streamable-http",
+      "headers": {
+        "x-api-key": "your-secret-key-here"
+      }
+    }
+  }
+}
+```
+
+**Claude Desktop Configuration:**
+
+```json
+{
+  "mcpServers": {
+    "my-mcp": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://namespace.adobeioruntime.net/api/v1/web/pkg/mcp-server",
+        "--header",
+        "x-api-key:${API_KEY}"
+      ],
+      "env": {
+        "API_KEY": "your-secret-key-here"
+      }
+    }
+  }
+}
+```
+
+### No Authentication (Development Only)
+
+Leave both variables unset for open access (not recommended for production).
+
+**Security Note:** Always use authentication in production deployments. Generate strong random values for `SERVICE_API_KEY` and never commit secrets to version control. 

--- a/src/templates/_dot.gitignore
+++ b/src/templates/_dot.gitignore
@@ -3,6 +3,7 @@
 node_modules
 
 .env*
+!.env.example
 .aio
 
 # Test output

--- a/src/templates/actions/mcp-server/index.js
+++ b/src/templates/actions/mcp-server/index.js
@@ -24,6 +24,7 @@ const { Core } = require('@adobe/aio-sdk')
 const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js')
 const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js')
 const { registerTools, registerResources, registerPrompts } = require('./tools.js')
+const { validateRequestAuth } = require('./validator.js')
 
 // SDK 1.24+ uses Web Standard transport. Optional module (see webpack externals) so build succeeds on 1.17.4.
 // undefined = not yet loaded; null = load failed or unavailable; otherwise the transport class.
@@ -447,9 +448,39 @@ async function main (params) {
 
         // Route requests
         const incomingHeaders = normalizeHeaders(params.__ow_headers)
+        const requestPath = params.__ow_path || ''
         
         switch (params.__ow_method?.toLowerCase()) {
         case 'get':
+            // Handle OAuth metadata requests - return proper JSON indicating OAuth is not supported
+            if (requestPath.includes('.well-known/oauth') || requestPath.includes('/oauth/') || requestPath.includes('/authorize') || requestPath.includes('/token')) {
+                logger.info('OAuth endpoint requested - returning not supported response')
+                const useIms = String(params.AUTH_VALIDATE_IMS || "").toLowerCase() === "true"
+                const serviceKey = params.SERVICE_API_KEY && String(params.SERVICE_API_KEY).trim()
+                
+                let authMessage = "This MCP server does not support OAuth. "
+                if (useIms) {
+                    authMessage += "IMS token authentication is required. Please configure your MCP client with 'Authorization: Bearer YOUR_IMS_TOKEN' header. See server documentation for configuration examples."
+                } else if (serviceKey) {
+                    authMessage += "API key authentication is required. Please configure your MCP client with 'Authorization: Bearer YOUR_API_KEY' or 'x-api-key: YOUR_API_KEY' header."
+                } else {
+                    authMessage += "No authentication is configured on this server."
+                }
+                
+                return {
+                    statusCode: 200,
+                    headers: {
+                        'Access-Control-Allow-Origin': '*',
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        error: "oauth_not_supported",
+                        error_description: authMessage,
+                        oauth_enabled: false
+                    })
+                }
+            }
+            
             // Check if client is requesting SSE stream
             // Return empty 200 response to gracefully indicate SSE is not available
             // This prevents error messages in MCP clients while allowing fallback to HTTP
@@ -474,7 +505,35 @@ async function main (params) {
             return handleOptionsRequest()
 
         case 'post':
-            logger.info('MCP protocol request - delegating to SDK')
+            logger.info('MCP protocol request - validating authentication')
+            
+            // Validate authentication if configured (only for POST requests)
+            const authResult = await validateRequestAuth(params, logger)
+            if (authResult.error) {
+                logger.warn('Authentication failed:', authResult.error)
+                return {
+                    statusCode: 401,
+                    headers: {
+                        'Access-Control-Allow-Origin': '*',
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        jsonrpc: '2.0',
+                        error: {
+                            code: -32001,
+                            message: authResult.error
+                        },
+                        id: null
+                    })
+                }
+            }
+            // Optionally attach userInfo to params for downstream use
+            if (authResult.userInfo) {
+                params.AUTH_USER_INFO = authResult.userInfo
+                logger.info('IMS authentication successful')
+            }
+            
+            logger.info('Authentication passed - delegating to SDK')
             return await handleMcpRequest(params)
 
         default:

--- a/src/templates/actions/mcp-server/validator.js
+++ b/src/templates/actions/mcp-server/validator.js
@@ -1,0 +1,139 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/**
+ * Request authentication for the MCP server action.
+ * - IMS: validate Bearer token via Adobe IMS userinfo
+ * - API key: require Authorization Bearer or x-api-key to match SERVICE_API_KEY
+ */
+
+const IMS_USERINFO_URL = "https://ims-na1.adobelogin.com/ims/userinfo/v2";
+
+/**
+ * Normalize request headers to lowercase keys.
+ * @param {Record<string, string>} raw
+ * @returns {Record<string, string>}
+ */
+function getHeadersNormalized(raw) {
+  if (!raw || typeof raw !== "object") return {};
+  return Object.keys(raw).reduce((acc, k) => {
+    acc[k.toLowerCase()] = raw[k];
+    return acc;
+  }, {});
+}
+
+/**
+ * Extract Bearer token or x-api-key from request params (__ow_headers).
+ * @param {Record<string, any>} params
+ * @returns {string}
+ */
+function getTokenFromRequest(params) {
+  const h = getHeadersNormalized(params.__ow_headers);
+  const authHeader = h["authorization"];
+  const apiKey = h["x-api-key"];
+  const bearer = authHeader && authHeader.startsWith("Bearer ") ? authHeader.slice(7).trim() : "";
+  return bearer || apiKey || "";
+}
+
+/**
+ * Validate Bearer token with Adobe IMS userinfo endpoint.
+ * GET ims/userinfo/v2 with Authorization: Bearer <token>; 200 => valid.
+ * @param {string} token - Bearer token (no "Bearer " prefix)
+ * @param {{ info?: (...args: any[]) => void, warn?: (...args: any[]) => void }} logger
+ * @returns {Promise<{ valid: boolean, userInfo?: object, error?: string }>}
+ */
+async function validateTokenWithIms(token, logger = console) {
+  if (!token || typeof token !== "string" || !token.trim()) {
+    return { valid: false, error: "Missing token" };
+  }
+  try {
+    const res = await fetch(IMS_USERINFO_URL, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token.trim()}` },
+    });
+    if (res.ok) {
+      const userInfo = await res.json().catch(() => ({}));
+      try { logger.info("[auth] IMS token valid", { status: res.status }); } catch {}
+      return { valid: true, userInfo };
+    }
+    const text = await res.text().catch(() => "");
+    try { logger.warn("[auth] IMS userinfo rejected token", { status: res.status, body: text.slice(0, 200) }); } catch {}
+    return {
+      valid: false,
+      error: res.status === 401 ? "Invalid or expired token" : `Token validation failed (${res.status})`,
+    };
+  } catch (e) {
+    try { logger.warn("[auth] IMS userinfo request failed", e?.message || e); } catch {}
+    return { valid: false, error: "Token validation unavailable" };
+  }
+}
+
+/**
+ * Validate request auth.
+ * - If AUTH_VALIDATE_IMS is true: require Authorization: Bearer <token>, validate via IMS userinfo.
+ * - Else if SERVICE_API_KEY is set: require same key in Authorization Bearer or x-api-key.
+ * - Else: no auth required.
+ * @param {Record<string, any>} params - action params (__ow_headers, SERVICE_API_KEY, AUTH_VALIDATE_IMS)
+ * @param {{ info?: (...args: any[]) => void, warn?: (...args: any[]) => void }} logger
+ * @returns {Promise<{ error?: string, token?: string, userInfo?: object }>} error set if invalid; token/userInfo set when IMS-validated
+ */
+async function validateRequestAuth(params, logger = console) {
+  const token = getTokenFromRequest(params);
+  const useIms = String(params.AUTH_VALIDATE_IMS || "").toLowerCase() === "true";
+  const serviceKey = params.SERVICE_API_KEY && String(params.SERVICE_API_KEY).trim();
+
+  if (useIms) {
+    if (!token) {
+      return { 
+        error: "IMS Authentication Required: No Bearer token provided. " +
+               "This MCP server has IMS token validation enabled (AUTH_VALIDATE_IMS=true). " +
+               "Please provide a valid Adobe IMS access token in the Authorization header " +
+               "(format: 'Authorization: Bearer YOUR_IMS_TOKEN') or via the x-api-key header. " +
+               "Configure your MCP client (Cursor/Claude) with the 'Authorization' or 'x-api-key' header. " +
+               "See server documentation for configuration examples."
+      };
+    }
+    const result = await validateTokenWithIms(token, logger);
+    if (result.valid) return { token, userInfo: result.userInfo };
+    return { 
+      error: `IMS Authentication Failed: ${result.error || "Invalid or expired token"}. ` +
+             "Please ensure you're using a valid Adobe IMS access token. " +
+             "You may need to refresh your token if it has expired."
+    };
+  }
+
+  if (serviceKey) {
+    if (!token) {
+      return { 
+        error: "API Key Authentication Required: No API key provided. " +
+               "This MCP server requires an API key (SERVICE_API_KEY is configured). " +
+               "Please provide the API key in the Authorization header " +
+               "(format: 'Authorization: Bearer YOUR_API_KEY') or via the x-api-key header."
+      };
+    }
+    if (token === serviceKey) return {};
+    return { 
+      error: "API Key Authentication Failed: Invalid API key provided. " +
+             "The API key does not match the configured SERVICE_API_KEY. " +
+             "Please check your API key and try again."
+    };
+  }
+
+  return {};
+}
+
+module.exports = {
+  getHeadersNormalized,
+  getTokenFromRequest,
+  validateTokenWithIms,
+  validateRequestAuth,
+};

--- a/src/templates/app.config.yaml
+++ b/src/templates/app.config.yaml
@@ -25,6 +25,12 @@ application:
             inputs:
               # Set log level (debug, info, warn, error)
               LOG_LEVEL: debug
+              # Authentication: IMS token validation or API key
+              # Set AUTH_VALIDATE_IMS=true to validate Bearer tokens via Adobe IMS
+              # Set SERVICE_API_KEY for simple API key authentication
+              # Leave both unset for no authentication (development only)
+              SERVICE_API_KEY: $SERVICE_API_KEY
+              AUTH_VALIDATE_IMS: $AUTH_VALIDATE_IMS
             annotations:
               # No Adobe authentication required for MCP servers
               require-adobe-auth: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add IMS and API_KEY Authentication to MCP server 

<!--- Describe your changes in detail -->

## Related Issue

This adds authentication layer to mcp template out of the box. All implementers are free to use the type of authentication but this adds a optional user IMS token validation as well as Service API KEY based authentication. 
## Motivation and Context

Though it depends on the MCP developer's choice but this adds an ootb support for safegaurding mcp from non authenticated users. 

## How Has This Been Tested?

It has been tested by :
Integrating it in agent and agent supplying IMS token to MCP, validating authentic request flow. follow Readme.for instructions 
Generating and configuring API_KEY , and configuring it in .env



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:


- [x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
